### PR TITLE
Add unittests for model classes

### DIFF
--- a/pfdl_scheduler/model/array.py
+++ b/pfdl_scheduler/model/array.py
@@ -62,6 +62,15 @@ class Array:
     def __radd__(self, other) -> str:
         return other + str(self)
 
+    def __eq__(self, __o: object) -> bool:
+        if isinstance(__o, Array):
+            return (
+                self.values == __o.values
+                and self.length == __o.length
+                and self.type_of_elements == __o.type_of_elements
+            )
+        return False
+
     def append_value(self, value: Any) -> None:
         """Adds an element to the array and increase the length.
 

--- a/pfdl_scheduler/model/struct.py
+++ b/pfdl_scheduler/model/struct.py
@@ -109,6 +109,12 @@ def parse_json(
             struct.attributes[identifier] = array
             for element in value:
                 if isinstance(element, (int, float, str, bool)):
+                    if isinstance(element, (int, float)):
+                        array.type_of_elements = "number"
+                    elif isinstance(element, bool):
+                        array.type_of_elements = "boolean"
+                    else:
+                        array.type_of_elements = "string"
                     array.append_value(element)
                 elif isinstance(element, dict):
                     inner_struct = parse_json(element, error_handler, struct_context)

--- a/pfdl_scheduler/model/struct.py
+++ b/pfdl_scheduler/model/struct.py
@@ -56,6 +56,16 @@ class Struct:
         self.context: ParserRuleContext = context
         self.context_dict: Dict = {}
 
+    def __eq__(self, __o: object) -> bool:
+        if isinstance(__o, Struct):
+            return (
+                self.name == __o.name
+                and self.attributes == __o.attributes
+                and self.context == __o.context
+                and self.context_dict == __o.context_dict
+            )
+        return False
+
     @classmethod
     def from_json(
         cls, json_string: str, error_handler: ErrorHandler, struct_context: ParserRuleContext

--- a/pfdl_scheduler/model/struct.py
+++ b/pfdl_scheduler/model/struct.py
@@ -109,10 +109,10 @@ def parse_json(
             struct.attributes[identifier] = array
             for element in value:
                 if isinstance(element, (int, float, str, bool)):
-                    if isinstance(element, (int, float)):
-                        array.type_of_elements = "number"
-                    elif isinstance(element, bool):
+                    if isinstance(element, bool):
                         array.type_of_elements = "boolean"
+                    elif isinstance(element, (int, float)):
+                        array.type_of_elements = "number"
                     else:
                         array.type_of_elements = "string"
                     array.append_value(element)

--- a/tests/unit_test/model/test_array.py
+++ b/tests/unit_test/model/test_array.py
@@ -1,0 +1,76 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the Array class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.array import Array
+
+# 3rd party libraries
+from antlr4.ParserRuleContext import ParserRuleContext
+
+
+class TestArray(unittest.TestCase):
+    """Tests for the methods of the Array class."""
+
+    def test_init(self):
+        array = Array()
+        self.assertEqual(array.type_of_elements, "")
+        self.assertEqual(array.values, [])
+        self.assertEqual(array.length, -1)
+        self.assertIsNone(array.context)
+
+        context = ParserRuleContext()
+        array = Array("int", [1, 2, 3], context)
+        self.assertEqual(array.type_of_elements, "int")
+        self.assertEqual(array.values, [1, 2, 3])
+        self.assertEqual(array.length, 3)
+        self.assertEqual(array.context, context)
+
+    def test_repr(self):
+        # Test with defined length
+        array = Array("int", [1, 2, 3])
+        self.assertEqual(repr(array), "int[3]")
+
+        # Test with undefined length
+        array = Array("int", [])
+        self.assertEqual(repr(array), "int[]")
+
+    def test_str(self):
+        # Test with defined length
+        array = Array("int", [1, 2, 3])
+        self.assertEqual(str(array), "int[3]")
+
+        # Test with undefined length
+        array = Array("int", [])
+        self.assertEqual(str(array), "int[]")
+
+    def test_add(self):
+        array = Array("int", [1, 2, 3])
+        self.assertEqual(array + "test", "int[3]test")
+        self.assertEqual("test" + array, "testint[3]")
+
+    def test_append_value(self):
+        array = Array("int", [])
+        array.append_value(1)
+        self.assertEqual(array.values, [1])
+        self.assertEqual(array.length, 1)
+
+        array.append_value(2)
+        self.assertEqual(array.values, [1, 2])
+        self.assertEqual(array.length, 2)
+
+    def test_length_defined(self):
+        # Test with defined length
+        array = Array("int", [1, 2, 3])
+        self.assertTrue(array.length_defined())
+
+        # Test with undefined length
+        array = Array("int", [])
+        self.assertFalse(array.length_defined())

--- a/tests/unit_test/model/test_array.py
+++ b/tests/unit_test/model/test_array.py
@@ -34,20 +34,20 @@ class TestArray(unittest.TestCase):
         self.assertEqual(array.context, context)
 
     def test_repr(self):
-        # Test with defined length
+        # test with defined length
         array = Array("int", [1, 2, 3])
         self.assertEqual(repr(array), "int[3]")
 
-        # Test with undefined length
+        # test with undefined length
         array = Array("int", [])
         self.assertEqual(repr(array), "int[]")
 
     def test_str(self):
-        # Test with defined length
+        # test with defined length
         array = Array("int", [1, 2, 3])
         self.assertEqual(str(array), "int[3]")
 
-        # Test with undefined length
+        # test with undefined length
         array = Array("int", [])
         self.assertEqual(str(array), "int[]")
 
@@ -67,10 +67,10 @@ class TestArray(unittest.TestCase):
         self.assertEqual(array.length, 2)
 
     def test_length_defined(self):
-        # Test with defined length
+        # test with defined length
         array = Array("int", [1, 2, 3])
         self.assertTrue(array.length_defined())
 
-        # Test with undefined length
+        # test with undefined length
         array = Array("int", [])
         self.assertFalse(array.length_defined())

--- a/tests/unit_test/model/test_condition.py
+++ b/tests/unit_test/model/test_condition.py
@@ -1,0 +1,38 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the Condition class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.condition import Condition
+from pfdl_scheduler.model.service import Service
+from pfdl_scheduler.model.task_call import TaskCall
+
+# 3rd party libraries
+from antlr4.ParserRuleContext import ParserRuleContext
+
+
+class TestCondition(unittest.TestCase):
+    """Tests for the methods of the Condition class."""
+
+    def test_init(self):
+        condition = Condition()
+        self.assertIsNone(condition.expression)
+        self.assertEqual(condition.passed_stmts, [])
+        self.assertEqual(condition.failed_stmts, [])
+        self.assertIsNone(condition.context)
+        self.assertEqual(condition.context_dict, {})
+
+        context = ParserRuleContext()
+        condition = Condition({"a": 1}, [Service("service")], [TaskCall("task")], context=context)
+        self.assertEqual(condition.expression, {"a": 1})
+        self.assertEqual(condition.passed_stmts, [Service("service")])
+        self.assertEqual(condition.failed_stmts, [TaskCall("task")])
+        self.assertEqual(condition.context, context)
+        self.assertEqual(condition.context_dict, {})

--- a/tests/unit_test/model/test_counting_loop.py
+++ b/tests/unit_test/model/test_counting_loop.py
@@ -1,0 +1,45 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the CountingLoop class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.counting_loop import CountingLoop
+from pfdl_scheduler.model.service import Service
+from pfdl_scheduler.model.task_call import TaskCall
+
+# 3rd party libraries
+from antlr4.ParserRuleContext import ParserRuleContext
+
+
+class TestCountingLoop(unittest.TestCase):
+    """Tests for the methods of the CountingLoop class."""
+
+    def test_init(self):
+        counting_loop = CountingLoop()
+        self.assertEqual(counting_loop.statements, [])
+        self.assertEqual(counting_loop.counting_variable, "")
+        self.assertEqual(counting_loop.limit, "")
+        self.assertEqual(counting_loop.parallel, False)
+        self.assertIsNone(counting_loop.context)
+
+        context = ParserRuleContext()
+        statements = [Service(name="service1"), TaskCall(name="task1")]
+        counting_loop = CountingLoop(
+            statements=statements,
+            counting_variable="i",
+            limit="10",
+            parallel=True,
+            context=context,
+        )
+        self.assertEqual(counting_loop.statements, statements)
+        self.assertEqual(counting_loop.counting_variable, "i")
+        self.assertEqual(counting_loop.limit, "10")
+        self.assertEqual(counting_loop.parallel, True)
+        self.assertEqual(counting_loop.context, context)

--- a/tests/unit_test/model/test_parallel.py
+++ b/tests/unit_test/model/test_parallel.py
@@ -1,0 +1,33 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the Parallel class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.parallel import Parallel
+from pfdl_scheduler.model.task_call import TaskCall
+
+# 3rd party libraries
+from antlr4.ParserRuleContext import ParserRuleContext
+
+
+class TestParallel(unittest.TestCase):
+    """Tests for the methods of the Parallel class."""
+
+    def test_init(self):
+        parallel = Parallel()
+        self.assertEqual(parallel.task_calls, [])
+        self.assertIsNone(parallel.context)
+        self.assertEqual(parallel.context_dict, {})
+
+        context = ParserRuleContext()
+        parallel = Parallel(task_calls=[TaskCall()], context=context)
+        self.assertEqual(parallel.task_calls, [TaskCall()])
+        self.assertEqual(parallel.context, context)
+        self.assertEqual(parallel.context_dict, {})

--- a/tests/unit_test/model/test_process.py
+++ b/tests/unit_test/model/test_process.py
@@ -1,0 +1,28 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the Process class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.process import Process
+from pfdl_scheduler.model.struct import Struct
+from pfdl_scheduler.model.task import Task
+
+
+class TestProcess(unittest.TestCase):
+    """Tests for the methods of the Process class."""
+
+    def test_init(self):
+        process = Process()
+        self.assertEqual(process.structs, {})
+        self.assertEqual(process.tasks, {})
+
+        process = Process(structs={"struct": Struct("struct_1")}, tasks={"task": Task()})
+        self.assertEqual(process.structs, {"struct": Struct("struct_1")})
+        self.assertEqual(process.tasks, {"task": Task()})

--- a/tests/unit_test/model/test_service.py
+++ b/tests/unit_test/model/test_service.py
@@ -1,0 +1,45 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the Service class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.service import Service
+from pfdl_scheduler.model.struct import Struct
+
+# 3rd party libraries
+from antlr4.ParserRuleContext import ParserRuleContext
+
+
+class TestService(unittest.TestCase):
+    """Tests for the methods of the Service class."""
+
+    def test_init(self):
+        service = Service()
+        self.assertEqual(service.name, "")
+        self.assertEqual(service.input_parameters, [])
+        self.assertEqual(service.output_parameters, {})
+        self.assertIsNone(service.context)
+        self.assertEqual(service.context_dict, {})
+
+        struct = Struct(name="TestStruct")
+        context = ParserRuleContext()
+        service = Service(
+            name="TestService",
+            input_parameters=["input1", ["input2", "input3"], struct],
+            output_parameters={"output1": "output1_type", "output2": ["output2_type"]},
+            context=context,
+        )
+        self.assertEqual(service.name, "TestService")
+        self.assertEqual(service.input_parameters, ["input1", ["input2", "input3"], struct])
+        self.assertEqual(
+            service.output_parameters, {"output1": "output1_type", "output2": ["output2_type"]}
+        )
+        self.assertIs(service.context, context)
+        self.assertEqual(service.context_dict, {})

--- a/tests/unit_test/model/test_struct.py
+++ b/tests/unit_test/model/test_struct.py
@@ -1,0 +1,141 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests tests for the Struct class and the 'parse_json' method."""
+
+# standard libraries
+from typing import Dict
+import unittest
+
+# local sources
+from pfdl_scheduler.model.struct import Struct
+from pfdl_scheduler.model.struct import parse_json
+from pfdl_scheduler.model.array import Array
+from pfdl_scheduler.validation.error_handler import ErrorHandler
+
+# 3rd party libraries
+from antlr4.ParserRuleContext import ParserRuleContext
+
+
+class TestStruct(unittest.TestCase):
+    """Tests for the methods of the Struct class."""
+
+    def test_init(self):
+        struct = Struct()
+        self.assertEqual(struct.name, "")
+        self.assertEqual(struct.attributes, {})
+        self.assertIsNone(struct.context)
+        self.assertEqual(struct.context_dict, {})
+
+        attributes = {
+            "attr1": "value",
+            "attr2": Array([1, 2, 3]),
+            "attr3": Struct(name="struct", attributes={"attr4": "value4"}),
+        }
+
+        context = ParserRuleContext()
+        struct = Struct(name="struct", attributes=attributes, context=context)
+        self.assertEqual(struct.name, "struct")
+        self.assertEqual(struct.attributes, attributes)
+        self.assertEqual(struct.context, context)
+        self.assertEqual(struct.context_dict, {})
+
+    def test_equal(self):
+        struct1 = Struct(name="struct1", attributes={"attr1": "value1"})
+        self.assertTrue(struct1 == struct1)
+
+        struct2 = Struct(name="struct1", attributes={"attr1": "value1"})
+        self.assertTrue(struct1 == struct2)
+
+        struct3 = Struct(name="struct1", attributes={"attr1": "value2"})
+        self.assertFalse(struct1 == struct3)
+
+        struct4 = Struct(name="struct1", attributes={"attr1": Array(["value1"])})
+        self.assertFalse(struct1 == struct4)
+
+        self.assertFalse(struct1 == "struct1")
+
+    def test_struct_from_json(self):
+        context = ParserRuleContext()
+
+        json_string = '{"attr1": "value1", "attr2": [1, 2, 3], "attr3": {"attr4": "value4"}}'
+        struct = Struct.from_json(json_string, ErrorHandler("", False), context)
+        self.assertEqual(struct.name, "")
+
+        attributes = {
+            "attr1": "value1",
+            "attr2": Array(values=[1, 2, 3], type_of_elements="number"),
+            "attr3": Struct(attributes={"attr4": "value4"}, context=context),
+        }
+        self.assertEqual(struct.attributes, attributes)
+
+        self.assertEqual(struct.context, context)
+        self.assertEqual(struct.context_dict, {})
+
+    def test_parse_json(self):
+        context = ParserRuleContext()
+
+        # empty
+        struct = parse_json({}, ErrorHandler("", False), context)
+        self.assertEqual(struct.name, "")
+        self.assertEqual(struct.attributes, {})
+        self.assertEqual(struct.context, context)
+        self.assertEqual(struct.context_dict, {})
+
+        # simple attributes
+        attributes = {"attr1": "value1", "attr2": 123, "attr3": True}
+        struct = parse_json(
+            {"attr1": "value1", "attr2": 123, "attr3": True}, ErrorHandler("", False), context
+        )
+        self.assertEqual(struct.name, "")
+
+        self.assertEqual(struct.attributes, attributes)
+        self.assertEqual(struct.context, context)
+        self.assertEqual(struct.context_dict, {})
+
+        # nested struct
+        struct_dict = {
+            "attr1": 5,
+            "attr2": [1, 2, 3],
+            "attr3": {"attr4": "value4"},
+            "attr5": {"attr6": ["str", "str_2"]},
+            "attr7": {"attr8": {"attr9": True}},
+            "attr10": [True, True, False],
+        }
+        struct = parse_json(struct_dict, ErrorHandler("", False), None)
+        self.assertEqual(struct.name, "")
+        self.assertEqual(
+            struct.attributes,
+            {
+                "attr1": 5,
+                "attr2": Array(values=[1, 2, 3], type_of_elements="number"),
+                "attr3": Struct(name="", attributes={"attr4": "value4"}),
+                "attr5": Struct(
+                    name="",
+                    attributes={"attr6": Array(values=["str", "str_2"], type_of_elements="string")},
+                ),
+                "attr7": Struct(
+                    name="", attributes={"attr8": Struct(name="", attributes={"attr9": True})}
+                ),
+                "attr10": Array(values=[True, True, False], type_of_elements="boolean"),
+            },
+        )
+
+        # structs in array
+        struct_dict = {
+            "attr1": [
+                {
+                    "attr2": 5,
+                },
+                {
+                    "attr3": "string",
+                },
+            ]
+        }
+        struct = parse_json(struct_dict, ErrorHandler("", False), None)
+        self.assertEqual(struct.name, "")
+        array = Array("", [Struct("", {"attr2": 5}), Struct("", {"attr3": "string"})])
+        self.assertEqual(struct.attributes, {"attr1": array})

--- a/tests/unit_test/model/test_struct.py
+++ b/tests/unit_test/model/test_struct.py
@@ -7,7 +7,6 @@
 """Contains unit tests tests for the Struct class and the 'parse_json' method."""
 
 # standard libraries
-from typing import Dict
 import unittest
 
 # local sources

--- a/tests/unit_test/model/test_task.py
+++ b/tests/unit_test/model/test_task.py
@@ -1,0 +1,52 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the Task class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.service import Service
+from pfdl_scheduler.model.task import Task
+from pfdl_scheduler.model.counting_loop import CountingLoop
+
+# 3rd party libraries
+from antlr4.ParserRuleContext import ParserRuleContext
+
+
+class TestTask(unittest.TestCase):
+    """Tests for the methods of the Task class."""
+
+    def test_init(self):
+        task = Task()
+        self.assertEqual(task.name, "")
+        self.assertEqual(task.statements, [])
+        self.assertEqual(task.variables, {})
+        self.assertEqual(task.input_parameters, {})
+        self.assertEqual(task.output_parameters, [])
+        self.assertIsNone(task.context)
+        self.assertEqual(task.context_dict, {})
+
+        context = ParserRuleContext()
+        task = Task(
+            name="task1",
+            statements=[Service(), CountingLoop(), CountingLoop(), Service()],
+            variables={"var1": "val1", "var2": "val2"},
+            input_parameters={"in1": "val4", "in2": "val5"},
+            output_parameters=["out1", "out2"],
+            context=context,
+        )
+        self.assertEqual(task.name, "task1")
+        self.assertEqual(len(task.statements), 4)
+        self.assertEqual(task.statements[0], Service())
+        self.assertEqual(task.statements[1], CountingLoop())
+        self.assertEqual(task.statements[2], CountingLoop())
+        self.assertEqual(task.statements[3], Service())
+        self.assertEqual(task.variables, {"var1": "val1", "var2": "val2"})
+        self.assertEqual(task.input_parameters, {"in1": "val4", "in2": "val5"})
+        self.assertEqual(task.output_parameters, ["out1", "out2"])
+        self.assertEqual(task.context, context)

--- a/tests/unit_test/model/test_task_call.py
+++ b/tests/unit_test/model/test_task_call.py
@@ -1,0 +1,34 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the TaskCall class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.task_call import TaskCall
+
+
+class TestTaskCall(unittest.TestCase):
+    """Tests for the methods of the TaskCall class."""
+
+    def test_init(self):
+        task_call = TaskCall()
+        self.assertEqual(task_call.name, "")
+        self.assertEqual(task_call.input_parameters, [])
+        self.assertEqual(task_call.output_parameters, {})
+
+        task_call = TaskCall(
+            "task_name",
+            ["input1", "input2"],
+            {"output1": "output1_value", "output2": "output2_value"},
+        )
+        self.assertEqual(task_call.name, "task_name")
+        self.assertEqual(task_call.input_parameters, ["input1", "input2"])
+        self.assertEqual(
+            task_call.output_parameters, {"output1": "output1_value", "output2": "output2_value"}
+        )

--- a/tests/unit_test/model/test_while_loop.py
+++ b/tests/unit_test/model/test_while_loop.py
@@ -1,0 +1,39 @@
+# Copyright The PFDL Contributors
+#
+# Licensed under the MIT License.
+# For details on the licensing terms, see the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+"""Contains unit tests for the WhileLoop class."""
+
+# standard libraries
+import unittest
+
+# local sources
+from pfdl_scheduler.model.service import Service
+from pfdl_scheduler.model.task_call import TaskCall
+from pfdl_scheduler.model.while_loop import WhileLoop
+
+# 3rd party libraries
+from antlr4.ParserRuleContext import ParserRuleContext
+
+
+class TestWhileLoop(unittest.TestCase):
+    """Tests for the methods of the WhileLoop class."""
+
+    def test_init(self):
+        while_loop = WhileLoop()
+        self.assertEqual(while_loop.statements, [])
+        self.assertEqual(while_loop.expression, {})
+        self.assertIsNone(while_loop.context)
+        self.assertEqual(while_loop.context_dict, {})
+
+        statements = [Service(), TaskCall()]
+        expression = "True"
+        context = ParserRuleContext()
+        while_loop = WhileLoop(statements, expression, context)
+        self.assertIsInstance(while_loop, WhileLoop)
+        self.assertEqual(while_loop.statements, statements)
+        self.assertEqual(while_loop.expression, expression)
+        self.assertEqual(while_loop.context, context)
+        self.assertEqual(while_loop.context_dict, {})

--- a/tests/unit_test/test_semantic_error_checker.py
+++ b/tests/unit_test/test_semantic_error_checker.py
@@ -50,8 +50,8 @@ class DummyContext:
 
 # ToDo: Check with mock objects if print error is called
 class TestSemanticErrorChecker(unittest.TestCase):
-    """
-    Tests the methods of the SemanticErrorChecker
+    """Tests the methods of the SemanticErrorChecker.
+
     Most methods will require a created Process object
     """
 


### PR DESCRIPTION
- Add unit tests for all model classes
- Fix bugs discovered during testing
- Implement `__eq__` methods for Array and Struct to enable comparison of objects of these classes