### PR TITLE
Add info about counting variables in callbacks

### DIFF
--- a/pfdl_scheduler/api/service_api.py
+++ b/pfdl_scheduler/api/service_api.py
@@ -3,25 +3,24 @@
 # Licensed under the MIT License.
 # For details on the licensing terms, see the LICENSE file.
 # SPDX-License-Identifier: MIT
-
 """Contains the ServiceAPI class."""
-
 # standard libraries
+import copy
+from typing import List, Union
 from uuid import uuid4
 from dataclasses import dataclass
 
 # local sources
 from pfdl_scheduler.api.task_api import TaskAPI
 from pfdl_scheduler.model.service import Service
+from pfdl_scheduler.model.struct import Struct
 
 
 @dataclass
 class ServiceAPI:
     """Represents a called Service.
-
     Represents a Service or Service Call in the langauge which can be mapped to a real
     service that can be executed.
-
     Attributes:
         service: A description of the called Service.
         task_context: A TaskAPI representaiton of the Task from which the service was called.
@@ -37,7 +36,6 @@ class ServiceAPI:
         in_loop: bool = False,
     ) -> None:
         """Initialize the object.
-
         Args:
             service: A description of the called Service.
             task_context: A TaskAPI representaiton of the Task from which the service was called.
@@ -51,3 +49,6 @@ class ServiceAPI:
         self.in_loop: bool = in_loop
         self.service: Service = service
         self.task_context: TaskAPI = task_context
+        self.input_parameters: List[Union[str, List[str], Struct]] = copy.deepcopy(
+            service.input_parameters
+        )

--- a/pfdl_scheduler/api/task_api.py
+++ b/pfdl_scheduler/api/task_api.py
@@ -7,8 +7,11 @@
 """Contains the TaskAPI class."""
 
 # standard libraries
+import copy
+from typing import List, Union
 from dataclasses import dataclass
 from uuid import uuid4
+from pfdl_scheduler.model.struct import Struct
 
 # local sources
 from pfdl_scheduler.model.task import Task
@@ -55,4 +58,11 @@ class TaskAPI:
         self.task: Task = task
         self.task_context: TaskAPI = task_context
         self.task_call: TaskCall = task_call
+
+        if task_call:
+            self.input_parameters: List[Union[str, List[str], Struct]] = copy.deepcopy(
+                task_call.input_parameters
+            )
+        else:
+            self.input_parameters: List[Union[str, List[str], Struct]] = []
         self.in_loop: bool = in_loop

--- a/pfdl_scheduler/model/array.py
+++ b/pfdl_scheduler/model/array.py
@@ -7,6 +7,7 @@
 """Contains the Array class."""
 
 # standard libraries
+import copy
 from typing import Any, List
 
 # 3rd party libraries
@@ -70,6 +71,17 @@ class Array:
                 and self.type_of_elements == __o.type_of_elements
             )
         return False
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for attr, value in self.__dict__.items():
+            try:
+                setattr(result, attr, copy.deepcopy(value, memo))
+            except Exception:
+                setattr(result, attr, value)
+        return result
 
     def append_value(self, value: Any) -> None:
         """Adds an element to the array and increase the length.

--- a/pfdl_scheduler/model/struct.py
+++ b/pfdl_scheduler/model/struct.py
@@ -7,6 +7,7 @@
 """Contains the Struct class."""
 
 # standard libraries
+import copy
 from dataclasses import dataclass
 from typing import Dict, Union
 import json
@@ -65,6 +66,17 @@ class Struct:
                 and self.context_dict == __o.context_dict
             )
         return False
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for attr, value in self.__dict__.items():
+            try:
+                setattr(result, attr, copy.deepcopy(value, memo))
+            except Exception:
+                setattr(result, attr, value)
+        return result
 
     @classmethod
     def from_json(

--- a/pfdl_scheduler/petri_net/generator.py
+++ b/pfdl_scheduler/petri_net/generator.py
@@ -431,29 +431,22 @@ class PetriNetGenerator:
         self.add_callback(first_transition_id, self.callbacks.parallel_loop_started, *args)
         return second_transition_id
 
-    def generate_parallel_loop_on_runtime(
-        self,
-        task_call: TaskCall,
-        task_context: TaskAPI,
-        task_count: int,
-        parallel_loop_started,
-        first_transition_id: str,
-        second_transition_id: str,
-        in_loop: bool = False,
-    ) -> None:
-        """Generates the dynamic petri net components for a ParallelLoop at runtime.
+    def remove_place_on_runtime(self, place_id: str) -> None:
+        """Removes a place from the petri net at runtime.
 
-        The amount of parallel started Tasks inside the ParallelLoop is only known at runtime.
-        This method will generate as many parallel TaskCalls
-        as specified in the task_count parameter.
+        Args:
+            place_id: The id as stringg of the task which should be removed from the net.
         """
-        for i in range(task_count):
-            self.generate_task_call(
-                task_call, task_context, first_transition_id, second_transition_id, in_loop
-            )
-        self.net.remove_place(parallel_loop_started)
+        self.net.remove_place(place_id)
         if self.draw_net:
             draw_petri_net(self.net, self.path_for_image)
+
+    def generate_empty_parallel_loop(
+        self, first_transition_id: str, second_transition_id: str
+    ) -> None:
+        empty_loop_place = create_place("Exeute 0 tasks", self.net)
+        self.net.add_output(empty_loop_place, first_transition_id, Value(1))
+        self.net.add_input(empty_loop_place, second_transition_id, Value(1))
 
     def generate_while_loop(
         self,

--- a/pfdl_scheduler/petri_net/logic.py
+++ b/pfdl_scheduler/petri_net/logic.py
@@ -30,7 +30,6 @@ class PetriNetLogic:
         petri_net: A reference to the generated petri net.
         draw_net: Indiciating whether the net should be drawn.
         transition_dict: A reference to the dict in the generator which maps the ids to callbacks.
-
     """
 
     def __init__(self, petri_net_generator: PetriNetGenerator, draw_net: bool = True):
@@ -70,20 +69,26 @@ class PetriNetLogic:
             if self.petri_net.transition(transition_id).enabled(Value(1)):
                 if transition_id in self.transition_dict:
                     callbacks = self.transition_dict[transition_id]
+                    temp = None
 
                     for callback in callbacks:
                         # parallel loop functionallity stop evaluation
                         if callback.func.__name__ == "on_parallel_loop_started":
-                            self.draw_petri_net(self.petri_net.name, self.petri_net)
-                            callbacks.remove(callback)
+                            temp = callback
+                            callbacks.remove(temp)
+
+                    if temp:
+                        # self.draw_petri_net(self.petri_net.name, self.petri_net)
+                        for callback in list(callbacks):
                             callback()
-                            return
+                            callbacks.remove(callback)
+                        temp()
+                        return
+                    else:
+                        self.petri_net.transition(transition_id).fire(Value(1))
 
-                    self.petri_net.transition(transition_id).fire(Value(1))
-
-                    for callback in callbacks:
-                        callback()  # run functools.partials() function here
-
+                        for callback in callbacks:
+                            callback()
                 else:
                     self.petri_net.transition(transition_id).fire(Value(1))
 

--- a/tests/unit_test/model/test_array.py
+++ b/tests/unit_test/model/test_array.py
@@ -7,6 +7,7 @@
 """Contains unit tests for the Array class."""
 
 # standard libraries
+import copy
 import unittest
 
 # local sources
@@ -55,6 +56,14 @@ class TestArray(unittest.TestCase):
         array = Array("int", [1, 2, 3])
         self.assertEqual(array + "test", "int[3]test")
         self.assertEqual("test" + array, "testint[3]")
+
+    def test_deepcopy(self):
+        # do not test context, as we cant control the copying of it
+        array = Array("int", [1, 2, 3])
+        copied_array = copy.deepcopy(array)
+        self.assertEqual(copied_array.type_of_elements, "int")
+        self.assertEqual(copied_array.values, [1, 2, 3])
+        self.assertEqual(copied_array.length, 3)
 
     def test_append_value(self):
         array = Array("int", [])

--- a/tests/unit_test/model/test_struct.py
+++ b/tests/unit_test/model/test_struct.py
@@ -7,6 +7,7 @@
 """Contains unit tests tests for the Struct class and the 'parse_json' method."""
 
 # standard libraries
+import copy
 import unittest
 
 # local sources
@@ -56,6 +57,15 @@ class TestStruct(unittest.TestCase):
         self.assertFalse(struct1 == struct4)
 
         self.assertFalse(struct1 == "struct1")
+
+    def test_deep_copy(self):
+        # do not test context, as we cant control the copying of it
+        attributes = {"attr_1": "number", "attr2": Struct("struct2", {"attr_3": "string"})}
+        struct = Struct("struct1", attributes, ParserRuleContext())
+        copied_struct = copy.deepcopy(struct)
+
+        self.assertEqual(copied_struct.name, "struct1")
+        self.assertEqual(copied_struct.attributes, attributes)
 
     def test_struct_from_json(self):
         context = ParserRuleContext()


### PR DESCRIPTION
Closes #14.

Changes:
- Add input parameters to Service API and Task API classes which are deep copies of the corresponding input parameters of the model classes
- Substitute all counting variables in the API classes (for example, if a task is started 3 times in a loop, do not provide the variable "i" in each callback, instead provide the ith iteration step, so 0, 1, 2
- Add deep copy methods in Struct and Array, as they are used in the input parameters
- Implement unit tests for the deep copy methods
- Fix a problem where the parallel loop would not be properly started if it were the first statement in a task