### PR TITLE
Fix bugs in SemanticErrorChecker

### DIFF
--- a/pfdl_scheduler/validation/semantic_error_checker.py
+++ b/pfdl_scheduler/validation/semantic_error_checker.py
@@ -348,14 +348,14 @@ class SemanticErrorChecker:
                     i = i + 1
                     current_struct = self.structs[element.type_of_elements]
                 else:
-                    current_struct = self.structs[element.name]
+                    current_struct = self.structs[element]
                 i = i + 1
 
             index = len(input_parameter) - 1
             if input_parameter[index].startswith("["):
                 given_type = current_struct.name
             else:
-                given_type = current_struct.attributes[input_parameter[index]].name
+                given_type = current_struct.attributes[input_parameter[index]]
             if given_type != defined_type:
                 error_msg = (
                     "Type of TaskCall parameter "
@@ -538,7 +538,7 @@ class SemanticErrorChecker:
                     self.check_for_unknown_attribute_in_struct(
                         struct_instance, identifier, struct_definition
                     )
-                    & self.check_for_wrong_attribute_type_in_struct(
+                    and self.check_for_wrong_attribute_type_in_struct(
                         struct_instance, identifier, struct_definition
                     )
                 ):

--- a/tests/unit_test/test_semantic_error_checker.py
+++ b/tests/unit_test/test_semantic_error_checker.py
@@ -586,11 +586,13 @@ class TestSemanticErrorChecker(unittest.TestCase):
         self.check_if_print_error_is_called(self.checker.check_if_input_parameter_matches, *args)
 
         # input parameter is List[str] without array
+
+        # struct definitions
         dummy_struct_a = Struct("Struct_1")
         dummy_struct_b = Struct("Struct_2")
         dummy_struct_c = Struct("Struct_3")
-        dummy_struct_a.attributes = {"b": dummy_struct_b}
-        dummy_struct_b.attributes = {"c": dummy_struct_c}
+        dummy_struct_a.attributes = {"b": "Struct_2"}
+        dummy_struct_b.attributes = {"c": "Struct_3"}
         task_context.variables = {"a": "Struct_1"}
         self.checker.structs = {
             "Struct_1": dummy_struct_a,
@@ -637,7 +639,7 @@ class TestSemanticErrorChecker(unittest.TestCase):
         array = Array("Struct_2", [Struct(), Struct()])
 
         dummy_struct_a.attributes = {"b": array}
-        dummy_struct_b.attributes = {"c": dummy_struct_c}
+        dummy_struct_b.attributes = {"c": "Struct_3"}
         task_context.variables = {"a": "Struct_1"}
         self.checker.structs = {
             "Struct_1": dummy_struct_a,


### PR DESCRIPTION
- Substitute & with and in `check_instantiated_struct_attributes`, because the second method should not be called if the first returns false
- Remove the name call in `check_if_input_parameter_matches` for elements in a list, as they strings and not structs
- Update unit tests for the made changes