### PR TITLE
Move license identifiers into header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,7 @@
-<!--
-SPDX-FileCopyrightText: The PFDL Contributors
-SPDX-License-Identifier: MIT
--->
 ---
+# SPDX-FileCopyrightText: The PFDL Contributors
+# SPDX-License-Identifier: MIT
+
 hide:
   - navigation
   - toc


### PR DESCRIPTION
Move the license identifiers into the header as comments, so the navigation inside the documentation is hidden again (expected behavior).