### PR TITLE
Fix typeerror when executing a counting loop after a parallel loop

### DIFF
--- a/pfdl_scheduler/model/counting_loop.py
+++ b/pfdl_scheduler/model/counting_loop.py
@@ -9,6 +9,8 @@
 # standard libraries
 from dataclasses import dataclass
 from typing import List, Union
+import uuid
+import hashlib
 
 # 3rd party libraries
 from antlr4.ParserRuleContext import ParserRuleContext
@@ -58,3 +60,7 @@ class CountingLoop(Loop):
         self.counting_variable: str = counting_variable
         self.limit: str = limit
         self.parallel: bool = parallel
+        self.uuid = str(uuid.uuid4())
+
+    def __hash__(self) -> int:
+        return int(uuid.UUID(self.uuid))

--- a/pfdl_scheduler/scheduler.py
+++ b/pfdl_scheduler/scheduler.py
@@ -371,14 +371,14 @@ class Scheduler(Subject):
         if self.loop_counters.get(task_context.uuid) is None:
             self.loop_counters[task_context.uuid] = {}
 
-        if self.loop_counters[task_context.uuid].get(loop.counting_variable) is None:
-            self.loop_counters[task_context.uuid][loop.counting_variable] = 0
+        if self.loop_counters[task_context.uuid].get(loop) is None:
+            self.loop_counters[task_context.uuid][loop] = 0
         else:
-            self.loop_counters[task_context.uuid][loop.counting_variable] = (
-                self.loop_counters[task_context.uuid][loop.counting_variable] + 1
+            self.loop_counters[task_context.uuid][loop] = (
+                self.loop_counters[task_context.uuid][loop] + 1
             )
 
-        loop_counter = self.loop_counters[task_context.uuid][loop.counting_variable]
+        loop_counter = self.loop_counters[task_context.uuid][loop]
         loop_limit = self.get_loop_limit(loop, task_context)
 
         if loop_counter < loop_limit:
@@ -389,10 +389,6 @@ class Scheduler(Subject):
         else:
             awaited_event = Event(event_type=SET_PLACE, data={"place_id": else_uuid})
             self.awaited_events.append(awaited_event)
-
-            # loop is done so reset loop counter for this task context
-            # set it to -1 because it exists now and will be incremented by 1
-            self.loop_counters[task_context.uuid][loop.counting_variable] = -1
 
             # has to be executed at last
             self.fire_event(awaited_event)


### PR DESCRIPTION
The bug was related to loop counters that are saved inside the loop_counter dict.
The key for the dict was the variable name, which resulted in errors if a ParallelLoop and a simple CountingLoop were used in the same task with the same counting variable.

A hashing method for CountingLoops was added, so that they can be used as keys inside the loop_counter dict.
Now, each loop has its own counter.

Fixes #31.