### PR TITLE
Always execute lint check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,19 +4,9 @@ on:
   push:
     branches:
       - 'main'
-    paths:
-      - 'pfdl_scheduler/**'
-      - 'tests/**'
-      - 'ci_lint_runner.py'
-      - '.github/workflows/**'
   pull_request:
     branches:
       - 'main'
-    paths:
-      - 'pfdl_scheduler/**'
-      - 'tests/**'
-      - 'ci_lint_runner.py'
-      - '.github/workflows/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
Ensure that the lint check is always performed on push and pull-requests on main. This fixes the corresponding mandatory check being stuck as in #45 and #46.