### PR TITLE
Remove pfdl_scheduler path

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,6 @@ plugins:
             python:
                 import:
                     - https://docs.python.org/3/objects.inv
-                paths: [pfdl_scheduler]  # search packages in the src folder
                 options:
                     merge_init_into_class: True
                     show_source: False


### PR DESCRIPTION
Remove old mkdocstrings path that results in an build error with newer versions of mkdocstrings.